### PR TITLE
Add hostname option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>com.google.endpoints</groupId>
       <artifactId>endpoints-framework-tools</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.7</version>
     </dependency>
     <!-- force the guava version because some maven tools use 18.0 -->
     <dependency>

--- a/src/main/java/com/google/cloud/tools/maven/endpoints/framework/ClientLibsMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/endpoints/framework/ClientLibsMojo.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.maven.endpoints.framework;
 import com.google.api.server.spi.tools.EndpointsTool;
 import com.google.api.server.spi.tools.GetClientLibAction;
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,6 +51,12 @@ public class ClientLibsMojo extends AbstractEndpointsWebAppMojo {
              property = "endpoints.clientLibDir", required = true)
   private File clientLibDir;
 
+  /**
+   * Default hostname of the Endpoint Host.
+   */
+  @Parameter(property = "endpoints.hostname")
+  private String hostname;
+
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (!clientLibDir.exists()) {
       if (!clientLibDir.mkdirs()) {
@@ -68,10 +75,15 @@ public class ClientLibsMojo extends AbstractEndpointsWebAppMojo {
           "-l", "java",
           "-bs", "maven",
           "-w", webappDir.getPath()));
+      if (!Strings.isNullOrEmpty(hostname)) {
+        params.add("-h");
+        params.add(hostname);
+      }
       if (serviceClasses != null) {
         params.addAll(serviceClasses);
       }
 
+      System.out.print(params);
       new EndpointsTool().execute(params.toArray(new String[params.size()]));
 
     } catch (Exception e) {

--- a/src/main/java/com/google/cloud/tools/maven/endpoints/framework/DiscoveryDocsMojo.java
+++ b/src/main/java/com/google/cloud/tools/maven/endpoints/framework/DiscoveryDocsMojo.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.maven.endpoints.framework;
 import com.google.api.server.spi.tools.EndpointsTool;
 import com.google.api.server.spi.tools.GetDiscoveryDocAction;
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +50,12 @@ public class DiscoveryDocsMojo extends AbstractEndpointsWebAppMojo {
              property = "endpoints.discoveryDocDir", required = true)
   private File discoveryDocDir;
 
+  /**
+   * Default hostname of the Endpoint Host.
+   */
+  @Parameter(property = "endpoints.hostname", required = false)
+  private String hostname;
+
   public void execute() throws MojoExecutionException {
     try {
       if (!discoveryDocDir.exists()) {
@@ -65,11 +72,17 @@ public class DiscoveryDocsMojo extends AbstractEndpointsWebAppMojo {
           "-o", discoveryDocDir.getPath(),
           "-cp", classpath,
           "-w", webappDir.getPath()));
+      if (!Strings.isNullOrEmpty(hostname)) {
+        params.add("-h");
+        params.add(hostname);
+      }
       if (serviceClasses != null) {
         params.addAll(serviceClasses);
       }
 
+      System.out.print(params);
       new EndpointsTool().execute(params.toArray(new String[params.size()]));
+
 
     } catch (Exception e) {
       throw new MojoExecutionException("Endpoints Tool Error", e);

--- a/src/test/java/com/google/cloud/tools/maven/endpoints/framework/ProjectTest.java
+++ b/src/test/java/com/google/cloud/tools/maven/endpoints/framework/ProjectTest.java
@@ -17,6 +17,17 @@
 
 package com.google.cloud.tools.maven.endpoints.framework;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.zip.ZipFile;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.apache.maven.it.util.ResourceExtractor;
@@ -24,19 +35,22 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.matchers.JUnitMatchers;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 
 public class ProjectTest {
 
+  private static final String DEFAULT_URL = "https://myapi.appspot.com/_ah/api";
+  private static final String DEFAULT_URL_PREFIX = "public static final String DEFAULT_ROOT_URL = ";
+  private static final String DEFAULT_URL_VARIABLE = DEFAULT_URL_PREFIX + "\"https://myapi.appspot.com/_ah/api/\";";
+  private static final String CLIENT_LIB_PATH = "target/client-libs/testApi-v1-java.zip";
+  private static final String DISC_DOC_PATH = "target/discovery-docs/testApi-v1-rest.discovery";
+  private static final String API_JAVA_FILE_PATH = "testApi/src/main/java/com/example/testApi/TestApi.java";
   public static String pluginVersion = null;
 
   @Rule
@@ -64,8 +78,51 @@ public class ProjectTest {
     verifier.executeGoals(
         Arrays.asList("endpoints-framework:clientLibs", "endpoints-framework:discoveryDocs"));
     verifier.verifyErrorFreeLog();
-    verifier.assertFilePresent("target/client-libs/testApi-v1-java.zip");
-    verifier.assertFilePresent("target/discovery-docs/testApi-v1-rest.discovery");
+    verifier.assertFilePresent(CLIENT_LIB_PATH);
+    verifier.assertFilePresent(DISC_DOC_PATH);
+
+    String apiJavaFile = getFileContentsInZip(new File(testDir, CLIENT_LIB_PATH), API_JAVA_FILE_PATH);
+    Assert.assertThat(apiJavaFile, JUnitMatchers.containsString(DEFAULT_URL_VARIABLE));
+
+    String discovery = Files.toString(new File(testDir, DISC_DOC_PATH), Charsets.UTF_8);
+    Assert.assertThat(discovery, JUnitMatchers.containsString(DEFAULT_URL));
+
+
+  }
+
+  @Test
+  public void testApplicationId() throws IOException, VerificationException {
+    File testDir = injectApplicationId(loadProject("/projects/server"), "<application>maven-test</application>");
+
+    Verifier verifier = new Verifier(testDir.getAbsolutePath());
+    verifier.executeGoals(
+        Arrays.asList("endpoints-framework:clientLibs", "endpoints-framework:discoveryDocs"));
+    verifier.verifyErrorFreeLog();
+
+    String apiJavaFile = getFileContentsInZip(new File(testDir, CLIENT_LIB_PATH), API_JAVA_FILE_PATH);
+    Assert.assertThat(apiJavaFile, JUnitMatchers.containsString(DEFAULT_URL_PREFIX + "\"https://maven-test.appspot.com/_ah/api/\";"));
+
+    String discovery = Files.toString(new File(testDir, DISC_DOC_PATH), Charsets.UTF_8);
+    Assert.assertThat(discovery, CoreMatchers.not(JUnitMatchers.containsString(DEFAULT_URL)));
+    Assert.assertThat(discovery, JUnitMatchers.containsString("https://maven-test.appspot.com/_ah/api"));
+  }
+
+  @Test
+  public void testHostnameAddon() throws IOException, VerificationException {
+    File testDir = injectConfiguration(loadProject("/projects/server"),
+        "<configuration><hostname>my.hostname.com</hostname></configuration>");
+
+    Verifier verifier = new Verifier(testDir.getAbsolutePath());
+    verifier.executeGoals(
+        Arrays.asList("endpoints-framework:clientLibs", "endpoints-framework:discoveryDocs"));
+    verifier.verifyErrorFreeLog();
+
+    String apiJavaFile = getFileContentsInZip(new File(testDir, CLIENT_LIB_PATH), API_JAVA_FILE_PATH);
+    Assert.assertThat(apiJavaFile, JUnitMatchers.containsString(DEFAULT_URL_PREFIX + "\"https://my.hostname.com/_ah/api/\";"));
+
+    String discovery = Files.toString(new File(testDir, DISC_DOC_PATH), Charsets.UTF_8);
+    Assert.assertThat(discovery, CoreMatchers.not(JUnitMatchers.containsString(DEFAULT_URL)));
+    Assert.assertThat(discovery, JUnitMatchers.containsString("https://my.hostname.com/_ah/api"));
   }
 
   @Test
@@ -79,7 +136,7 @@ public class ProjectTest {
   }
 
   private File loadProject(String path) throws IOException {
-    File dir = ResourceExtractor.extractResourcePath(ProjectTest.class, path, testRoot.getRoot());
+    File dir = ResourceExtractor.extractResourcePath(ProjectTest.class, path, testRoot.getRoot(), true);
 
     File pom = new File(dir, "pom.xml");
     String pomContents = FileUtils.fileRead(pom);
@@ -87,5 +144,29 @@ public class ProjectTest {
     FileUtils.fileWrite(pom, pomContents);
 
     return dir;
+  }
+
+  // inject a endpoints plugin configuration into the pom.xml
+  private File injectConfiguration(File root, String configuration) throws IOException {
+    File pom = new File(root, "pom.xml");
+    String pomContents = FileUtils.fileRead(pom);
+    pomContents = pomContents.replaceAll("<!--endpoints-plugin-configuration-->", configuration);
+    FileUtils.fileWrite(pom, pomContents);
+    return root;
+  }
+
+  // inject an application tag into the appengine-web.xml
+  private File injectApplicationId(File root, String application) throws IOException {
+    File app = new File(root, "src/main/webapp/WEB-INF/appengine-web.xml");
+    String appContents = FileUtils.fileRead(app);
+    appContents = appContents.replaceAll("<!--application-->", application);
+    FileUtils.fileWrite(app, appContents);
+    return root;
+  }
+
+  private String getFileContentsInZip(File zipFile, String path) throws IOException {
+    ZipFile zip = new ZipFile(zipFile);
+    InputStream is = zip.getInputStream(zip.getEntry(path));
+    return CharStreams.toString(new InputStreamReader(is, Charsets.UTF_8));
   }
 }

--- a/src/test/resources/projects/server/pom.xml
+++ b/src/test/resources/projects/server/pom.xml
@@ -13,9 +13,10 @@
     <java.target.version>1.7</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <appengine-maven-plugin.version>1.0.0</appengine-maven-plugin.version>
-    <appengine-dependencies.version>1.9.48</appengine-dependencies.version>
+    <appengine-maven-plugin.version>1.3.0</appengine-maven-plugin.version>
+    <appengine-dependencies.version>1.9.51</appengine-dependencies.version>
     <endpoints-framework-maven-plugin.version>@@PluginVersion@@</endpoints-framework-maven-plugin.version>
+    <endpoints-framework.version>2.0.7</endpoints-framework.version>
   </properties>
 
   <dependencies>
@@ -29,7 +30,7 @@
     <dependency>
       <groupId>com.google.endpoints</groupId>
       <artifactId>endpoints-framework</artifactId>
-      <version>2.0.0-beta.12</version>
+      <version>${endpoints-framework.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>
@@ -42,13 +43,6 @@
       <version>1</version>
     </dependency>
   </dependencies>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <build>
     <plugins>
@@ -83,8 +77,7 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>endpoints-framework-maven-plugin</artifactId>
         <version>${endpoints-framework-maven-plugin.version}</version>
-        <configuration>
-        </configuration>
+        <!--endpoints-plugin-configuration-->
       </plugin>
     </plugins>
 

--- a/src/test/resources/projects/server/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/test/resources/projects/server/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>some-nonsense</application>
+
+    <!--application-->
     <threadsafe>true</threadsafe>
 
     <system-properties>

--- a/src/test/resources/projects/server/src/main/webapp/WEB-INF/web.xml
+++ b/src/test/resources/projects/server/src/main/webapp/WEB-INF/web.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?><web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <servlet>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <servlet-class>com.google.api.server.spi.SystemServiceServlet</servlet-class>
+        <servlet-name>EndpointsServlet</servlet-name>
+        <servlet-class>com.google.api.server.spi.EndpointsServlet</servlet-class>
         <init-param>
             <param-name>services</param-name>
             <param-value>com.example.Test</param-value>
         </init-param>
     </servlet>
     <servlet-mapping>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <url-pattern>/_ah/spi/*</url-pattern>
+        <servlet-name>EndpointsServlet</servlet-name>
+        <url-pattern>/_ah/api/*</url-pattern>
     </servlet-mapping>
 </web-app>


### PR DESCRIPTION
Allow users to specify hostname (like `myapp.appspot.com`) to set the default root-url for clients and discovery docs. It's never been needed, but it is a convenience option for developers that want a working default. Users can still use `.setRootUrl` to override the default when making calls with the client library.

This used to be derived from the `<application>` tag in appengine-web.xml, but we are phasing out that tag in favor of specifying the project in `gcloud app deploy --project`.